### PR TITLE
enable deepep fused_moe

### DIFF
--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -676,6 +676,35 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
         self.packed_recv_count = self.handle = None
         return combined_hidden_states, event, hook
 
+    def fused_moe(
+        self,
+        hidden_states: torch.Tensor,
+        topk_idx: torch.Tensor,
+        topk_weights: torch.Tensor,
+        gmm1_permuted_weight: torch.Tensor,
+        gmm1_permuted_weight_scale: torch.Tensor,
+        gmm2_weight: torch.Tensor,
+        gmm2_weight_scale: torch.Tensor,
+        quant_mode: int,
+    ):
+        buffer = self._get_buffer()
+        topk_idx = topk_idx.to(torch.int64)
+
+        hidden_states, _ = buffer.fused_deep_moe(
+            hidden_states,
+            topk_idx,
+            topk_weights,
+            gmm1_permuted_weight,
+            gmm1_permuted_weight_scale,
+            gmm2_weight,
+            gmm2_weight_scale,
+            self.num_max_dispatch_tokens_per_rank,
+            self.num_experts,
+            quant_mode,
+        )
+
+        return hidden_states
+
     def _get_buffer(self):
         DeepEPBuffer.set_dispatch_mode_as_low_latency()
         return DeepEPBuffer.get_deepep_buffer(
@@ -806,3 +835,29 @@ class DeepEPDispatcher(BaseDispatcher):
             self._low_latency_dispatcher.set_quant_config(quant_config)
         if self.deepep_mode.enable_normal():
             self._normal_dispatcher.set_quant_config(quant_config)
+
+    def fused_moe(self, *args, **kwargs) -> Tuple:
+        return self._fused_moe_impl(*args, **kwargs)
+
+    def _fused_moe_impl(
+        self,
+        hidden_states: torch.Tensor,
+        topk_idx: torch.Tensor,
+        topk_weights: torch.Tensor,
+        gmm1_permuted_weight: torch.Tensor,
+        gmm1_permuted_weight_scale: torch.Tensor,
+        gmm2_weight: torch.Tensor,
+        gmm2_weight_scale: torch.Tensor,
+        quant_mode: int,
+    ):
+        hidden_states = self._get_impl().fused_moe(
+            hidden_states=hidden_states,
+            topk_idx=topk_idx,
+            topk_weights=topk_weights,
+            gmm1_permuted_weight=gmm1_permuted_weight,
+            gmm1_permuted_weight_scale=gmm1_permuted_weight_scale,
+            gmm2_weight=gmm2_weight,
+            gmm2_weight_scale=gmm2_weight_scale,
+            quant_mode=quant_mode,
+        )
+        return hidden_states

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -906,21 +906,21 @@ class DeepseekV2MoE(nn.Module):
     ) -> torch.Tensor:
         shared_output = None
         if hidden_states.shape[0] > 0:
-            # prefetch and forward share experts on the same stream
-            main_event = torch.npu.Event()
-            main_event.record()
-            cmo_stream = get_cmo_stream()
-            with torch.npu.stream(cmo_stream):
-                cmo_stream.wait_event(main_event)
-                shared_output = self._forward_shared_experts(hidden_states)
-                if _is_npu:
-                    PREFETCH_MAX_SIZE = 1000000000
-                    for weight in [self.experts.w13_weight, self.experts.w2_weight]:
-                        torch_npu.npu_prefetch(weight, shared_output, PREFETCH_MAX_SIZE)
+            if not self._fuse_shared_experts_inside_sbo:
+                # prefetch and forward share experts on the same stream
+                main_event = torch.npu.Event()
+                main_event.record()
+                cmo_stream = get_cmo_stream()
+                with torch.npu.stream(cmo_stream):
+                    cmo_stream.wait_event(main_event)
+                    shared_output = self._forward_shared_experts(hidden_states)
+                    if _is_npu:
+                        PREFETCH_MAX_SIZE = 1000000000
+                        for weight in [self.experts.w13_weight, self.experts.w2_weight]:
+                            torch_npu.npu_prefetch(weight, shared_output, PREFETCH_MAX_SIZE)
+
             # router_logits: (num_tokens, n_experts)
             router_logits = self.gate(hidden_states)
-            if not self._fuse_shared_experts_inside_sbo:
-                shared_output = self._forward_shared_experts(hidden_states)
             topk_output = self.topk(
                 hidden_states,
                 router_logits,
@@ -1405,7 +1405,7 @@ class DeepseekV2AttentionMLA(nn.Module):
                 [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim], dim=-1
             )  # 1536 / 512+64
             q_lora = self.q_a_layernorm(q)
-            torch.npu.current_stream().wait_event(indexer_stream)
+            torch.npu.current_stream().wait_stream(indexer_stream)
         else:
             if self.mla_preprocess is None:
                 self.mla_preprocess = NPUMLAProlog(

--- a/python/sglang/srt/two_batch_overlap.py
+++ b/python/sglang/srt/two_batch_overlap.py
@@ -1004,3 +1004,6 @@ class MaybeTboDeepEPDispatcher:
     def set_quant_config(self, quant_config: dict):
         for inner in self._inners:
             inner.set_quant_config(quant_config)
+
+    def fused_moe(self, **kwargs) -> torch.Tensor:
+        return self._execute("fused_moe", **kwargs)


### PR DESCRIPTION
## Modifications
1. 适配 deepep fused_moe 融合算子，暂时需要开启环境变量
- export TASK_QUEUE_ENABLE=0 
- export ENABLE_FUSED_MOE=1
- decode启动脚本参数添加 --moe-a2a-backend deepep --deepep-mode low_latency
2. 修复多流修改带来的 shared_output 重复计算问题；
3. 修复mtp场景未使能 torch.ops.npu.batch_matmul_transpose 算子问题。
